### PR TITLE
Install Claude Code and add assistant playbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,83 @@
 # K Fitness Center
 
-A static landing page/infographic for the **K Fitness Center – Automated Content Creation System** workflow.
+A static landing page/infographic and knowledge base for the **K Fitness Center – Automated Content Creation System** workflow.
+
+## Business Source of Truth
+
+| Field | Official information |
+| --- | --- |
+| Gym name | K Fitness Center |
+| Location | Shwe Kokko Myain, Myawaddy |
+| Google Map | https://maps.app.goo.gl/pDefLUxTmSoZ3RB18?g_st=ipc |
+| Phone numbers | 09966766466, 09676003533, 09675844933 |
+| Opening hours | Monday to Saturday, 6:00 AM to 1:00 AM |
+| Sunday | Closed |
+
+### Pricing
+
+| Plan or service | Price |
+| --- | --- |
+| Single visit | 250฿ |
+| Monthly plan | 1700฿ + 300฿ membership fee |
+| 3-month plan | 5000฿ with 1 month free |
+| 6-month plan | 10000฿ with 3 months free |
+| Private Coach | +2000฿ |
+| Pickup service | +2000฿ |
+
+### Free Group Classes
+
+Aerobics, Zumba, Trampoline, and Step Board are free group classes for members.
+
+### Services
+
+K Fitness Center supports Muscle gain, fat loss, CrossFit, private coaching, nutrition guidance, and pickup service.
+
+## Official AI Assistant Role
+
+The official assistant answers customer questions about prices, opening hours, services, membership options, location, contact numbers, and marketing posts. It supports Myanmar, English, Chinese, and bilingual Myanmar-English customer conversations.
+
+For detailed response scripts and templates, use `docs/assistant-playbook.md`.
+
+## Sales Style
+
+1. Answer the question directly.
+2. Highlight the customer benefit.
+3. Recommend the best plan for the customer's goal.
+4. Ask for the next action and include a contact number when closing.
+
+## Safety Rules
+
+- Do not provide medical diagnosis.
+- Do not promise exact weight-loss results.
+- If a customer mentions pain, injury, dizziness, pregnancy, or any health condition, ask them to consult a qualified medical professional before training.
+- Fitness guidance is general information and not a replacement for professional medical advice.
+
+## Marketing Post Structure
+
+Use this five-part structure for Facebook, Telegram, TikTok, and YouTube content:
+
+1. **Question** — open with a relatable customer problem.
+2. **Emotion** — connect with the customer's goal or frustration.
+3. **Trust** — mention K Fitness Center coaching, safety, and support.
+4. **Offer** — recommend the right plan, class, or service.
+5. **Close** — give phone numbers and the map link.
+
+## Claude Code Installation
+
+Claude Code has been installed in this environment using the official npm package:
+
+```bash
+npm install -g @anthropic-ai/claude-code@latest
+claude --version
+```
+
+Verified installed version: `2.1.185 (Claude Code)`.
+
+Requirements and maintenance notes:
+
+- Node.js 18 or later is required; this environment has Node.js 20.20.2.
+- Do not use `sudo npm install -g` for Claude Code.
+- Upgrade with `npm install -g @anthropic-ai/claude-code@latest`.
 
 ## Preview locally
 

--- a/docs/assistant-playbook.md
+++ b/docs/assistant-playbook.md
@@ -1,0 +1,137 @@
+# K Fitness Center AI Assistant Playbook
+
+## Core Identity
+
+K Fitness Center is a gym in Shwe Kokko Myain, Myawaddy. The assistant should be friendly, sales-focused, accurate, and safety-minded. K Fitness Center helps customers train for muscle gain, fat loss, CrossFit fitness, private coaching, nutrition guidance, and pickup service.
+
+Contacts: 09966766466, 09676003533, 09675844933. Map: https://maps.app.goo.gl/pDefLUxTmSoZ3RB18?g_st=ipc.
+
+## Language Policy
+
+- Myanmar customer: reply in Myanmar language.
+- English customer: reply in English.
+- Chinese customer: reply in Chinese.
+- Mixed Myanmar-English customer: use Myanmar-English bilingual style.
+- Reply in the same language the customer uses unless they ask otherwise.
+
+## Quick Customer Answers
+
+### Opening Hours
+
+English: K Fitness Center opens Monday to Saturday from 6:00 AM to 1:00 AM. Sunday is closed.
+
+Myanmar: K Fitness Center ကို Monday to Saturday မနက် 6:00 AM မှ ည 1:00 AM အထိ ဖွင့်ပါတယ်။ Sunday ပိတ်ပါတယ်။
+
+Chinese: K Fitness Center 周一到周六营业，时间是早上 6:00 AM 到凌晨 1:00 AM。周日休息。
+
+### Prices
+
+English prices:
+- Single visit: 250฿
+- Monthly plan: 1700฿ + 300฿ membership fee
+- 3-month plan: 5000฿ with 1 month free
+- 6-month plan: 10000฿ with 3 months free
+- Private Coach: +2000฿
+- Pickup service: +2000฿
+
+Myanmar prices:
+- တစ်ခါကစား: 250฿
+- တစ်လ: 1700฿ + membership fee 300฿
+- 3 months: 5000฿ with 1 month free
+- 6 months: 10000฿ with 3 months free
+- Private Coach: +2000฿
+- Pickup service: +2000฿
+
+Chinese prices:
+- 单次：250฿
+- 月卡：1700฿ + 300฿ 会员费
+- 3个月：5000฿，送 1 month free
+- 6个月：10000฿，送 3 months free
+- Private Coach: +2000฿
+- Pickup service: +2000฿
+
+### Free Classes
+
+Aerobics, Zumba, Trampoline, and Step Board are free group classes.
+
+### Services
+
+Services include muscle gain, fat loss, CrossFit, private coaching, nutrition guidance, and pickup service.
+
+## Sales Closing Scripts
+
+### New Customer Asking Price
+
+The best starter choice is the Monthly plan because you can try the gym consistently, join free group classes, and build a routine. Monthly plan is 1700฿ + 300฿ membership fee. Contact 09966766466 or visit https://maps.app.goo.gl/pDefLUxTmSoZ3RB18?g_st=ipc.
+
+### Fat Loss Customer
+
+For fat loss, we do not promise exact kg loss because every body responds differently; instead, we focus on safe training, nutrition guidance, and consistency. The Monthly plan or 3-month plan is recommended for better habit building.
+
+### Muscle Gain Customer
+
+For muscle gain, we recommend strength training with progressive overload, nutrition guidance, and optional private coach support. The 3-month plan is a strong choice because it includes 1 month free.
+
+### Customer With Pain or Injury
+
+If you have pain, injury, dizziness, or a health condition, please consult a medical professional before training. Myanmar: နာကျင်မှု၊ injury၊ မူးဝေခြင်းရှိရင် training မလုပ်ခင် ဆရာဝန် နှင့် တိုင်ပင်ပါ။
+
+### Myanmar-English bilingual
+
+K Fitness Center မှာ fat loss / muscle gain goal အတွက် coach support နဲ့ safe training plan ရပါတယ်။ အသေးစိတ်မေးချင်ရင် 09966766466 ကို ဆက်သွယ်နိုင်ပါတယ်။
+
+## Safety Rules
+
+- For pain, injury, dizziness, pregnancy, or medical conditions, advise customers to consult a medical professional before training.
+- For fat loss, do not promise exact kg loss.
+- YouTube and social descriptions must include: consult a medical professional before training if you have pain, injury, dizziness, pregnancy, or a health condition.
+
+## Marketing Content Templates
+
+### Facebook / Telegram Post
+
+**Question**: Want to lose fat, gain muscle, or get stronger?
+
+**Emotion**: It can feel hard to start alone, but the right gym support makes training easier.
+
+**Trust**: K Fitness Center provides coaching, free classes, CrossFit, nutrition guidance, and a safe training environment.
+
+**Offer**: Start with the Monthly plan, or choose 5000฿ for 3 months with 1 month free.
+
+**Close**: Call 09966766466, 09676003533, or 09675844933. Map: https://maps.app.goo.gl/pDefLUxTmSoZ3RB18?g_st=ipc.
+
+### TikTok / Reels Short Video Script
+
+**Hook**: Stop guessing your workout plan.
+
+Show quick clips of warm-up, CrossFit, strength training, and group classes.
+
+**Call to Action**: Visit K Fitness Center today or call 09966766466.
+
+### YouTube Video Idea
+
+**Title**: Beginner Workout Guide at K Fitness Center
+
+**Description**: Learn a safe beginner workout plan for strength, fat loss, and confidence. If you have pain, injury, dizziness, pregnancy, or a health condition, consult a medical professional before training. Contact 09966766466 or visit https://maps.app.goo.gl/pDefLUxTmSoZ3RB18?g_st=ipc.
+
+## Content Creation Workflow
+
+1. Topic ideas
+2. Content planning
+3. Content generation
+4. Image generation
+5. Video generation
+6. Publish and distribute
+7. Review performance
+
+## Weekly Automated Output Calendar
+
+| Day | Content | Channel |
+| --- | --- | --- |
+| Monday | Strength training infographic | Facebook |
+| Tuesday | HIIT short video | TikTok |
+| Wednesday | Nutrition guidance post | Facebook |
+| Thursday | Beginner guide video | YouTube |
+| Friday | Motivation and offer post | Facebook |
+| Saturday | Ask-a-trainer Q&A | TikTok |
+| Sunday | Rest day motivation | YouTube |

--- a/tests/test_gitignore.py
+++ b/tests/test_gitignore.py
@@ -1,0 +1,122 @@
+"""
+Tests for .gitignore — K Fitness Center repository.
+
+Validates that the .gitignore added in this PR correctly defines the expected
+ignore patterns for Python bytecode and cache directories.
+"""
+
+import os
+import re
+import unittest
+
+GITIGNORE_PATH = os.path.join(os.path.dirname(__file__), "..", ".gitignore")
+
+
+def read_gitignore() -> str:
+    with open(GITIGNORE_PATH, encoding="utf-8") as f:
+        return f.read()
+
+
+class TestGitignorePatterns(unittest.TestCase):
+    """Core pattern presence tests."""
+
+    def setUp(self):
+        self.content = read_gitignore()
+
+    def test_file_exists(self):
+        """The .gitignore file must exist at the repository root."""
+        self.assertTrue(os.path.isfile(GITIGNORE_PATH), ".gitignore not found at repository root")
+
+    def test_file_is_not_empty(self):
+        """The .gitignore must not be empty."""
+        self.assertGreater(len(self.content.strip()), 0)
+
+    def test_pycache_directory_pattern_present(self):
+        """__pycache__/ must be listed to exclude Python bytecode cache directories."""
+        self.assertIn("__pycache__/", self.content)
+
+    def test_pyc_cod_pattern_present(self):
+        """*.py[cod] must be listed to exclude compiled Python files (.pyc, .pyo, .pyd)."""
+        self.assertIn("*.py[cod]", self.content)
+
+    def test_pycache_pattern_on_own_line(self):
+        """__pycache__/ must appear on its own line, not embedded in another pattern."""
+        lines = self.content.splitlines()
+        pycache_lines = [ln.strip() for ln in lines if "__pycache__/" in ln]
+        self.assertTrue(
+            any(ln == "__pycache__/" for ln in pycache_lines),
+            "__pycache__/ must be a standalone pattern line",
+        )
+
+    def test_pyc_cod_pattern_on_own_line(self):
+        """*.py[cod] must appear on its own line."""
+        lines = self.content.splitlines()
+        pyc_lines = [ln.strip() for ln in lines if "*.py[cod]" in ln]
+        self.assertTrue(
+            any(ln == "*.py[cod]" for ln in pyc_lines),
+            "*.py[cod] must be a standalone pattern line",
+        )
+
+    def test_both_patterns_present(self):
+        """Both Python-related ignore patterns must exist together."""
+        self.assertIn("__pycache__/", self.content)
+        self.assertIn("*.py[cod]", self.content)
+
+
+class TestGitignoreEdgeCases(unittest.TestCase):
+    """Boundary and regression checks."""
+
+    def setUp(self):
+        self.content = read_gitignore()
+        self.lines = self.content.splitlines()
+
+    def test_no_crlf_line_endings(self):
+        """File must use Unix line endings (LF), not Windows CRLF."""
+        self.assertNotIn("\r", self.content, ".gitignore should not contain carriage returns (CRLF)")
+
+    def test_file_ends_with_newline(self):
+        """Well-formed text files should end with a newline character."""
+        self.assertTrue(self.content.endswith("\n"), ".gitignore should end with a trailing newline")
+
+    def test_no_secret_paths_accidentally_ignored(self):
+        """The .gitignore must not accidentally exclude .env files or credential files."""
+        sensitive_patterns = [".env", "credentials", "secrets", "id_rsa", "*.pem"]
+        for pattern in sensitive_patterns:
+            with self.subTest(pattern=pattern):
+                self.assertNotIn(pattern, self.content)
+
+    def test_pyc_bracket_pattern_covers_pyc(self):
+        """Verify the [cod] character-class pattern logically covers .pyc extension."""
+        # The pattern *.py[cod] should match filenames ending in .pyc, .pyo, .pyd.
+        import fnmatch
+        for ext in ("example.pyc", "example.pyo", "example.pyd"):
+            with self.subTest(filename=ext):
+                self.assertTrue(fnmatch.fnmatch(ext, "*.py[cod]"), f"Pattern *.py[cod] should match {ext}")
+
+    def test_pycache_pattern_does_not_match_plain_files(self):
+        """__pycache__/ (with trailing slash) applies to directories, not plain files named __pycache__."""
+        # The slash suffix means git only ignores directories; a plain file should not be caught.
+        # Verify that the pattern in the file retains the trailing slash.
+        lines = self.content.splitlines()
+        pycache_entry = next((ln.strip() for ln in lines if "__pycache__" in ln), None)
+        self.assertIsNotNone(pycache_entry, "__pycache__ entry must exist")
+        self.assertTrue(
+            pycache_entry.endswith("/"),
+            "__pycache__ pattern must end with / to target directories only",
+        )
+
+    def test_non_python_source_files_not_ignored(self):
+        """Common source files (.html, .css, .md, .js) must not be accidentally excluded."""
+        for ext_pattern in ("*.html", "*.css", "*.md", "*.js"):
+            with self.subTest(pattern=ext_pattern):
+                self.assertNotIn(ext_pattern, self.content)
+
+    def test_no_negation_of_pycache_pattern(self):
+        """No negation rule (!) should re-include __pycache__ after ignoring it."""
+        lines = [ln.strip() for ln in self.content.splitlines()]
+        negation_lines = [ln for ln in lines if ln.startswith("!") and "__pycache__" in ln]
+        self.assertEqual(len(negation_lines), 0, "No rule should re-include __pycache__")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_readme.py
+++ b/tests/test_readme.py
@@ -319,5 +319,75 @@ class TestReadmeEdgeCases(unittest.TestCase):
         self.assertEqual(len(h1_matches), 1, "README should have exactly one H1 heading")
 
 
+class TestReadmeClaudeCodeInstallation(unittest.TestCase):
+    """Claude Code installation section added in this PR must be accurate."""
+
+    def setUp(self):
+        self.content = read_readme()
+
+    def test_claude_code_installation_section_exists(self):
+        """'Claude Code Installation' section must be present."""
+        self.assertIn("## Claude Code Installation", self.content)
+
+    def test_npm_install_command_present(self):
+        """The npm global install command must appear verbatim."""
+        self.assertIn("npm install -g @anthropic-ai/claude-code@latest", self.content)
+
+    def test_package_name_is_anthropic_claude_code(self):
+        """The official package name @anthropic-ai/claude-code must be referenced."""
+        self.assertIn("@anthropic-ai/claude-code", self.content)
+
+    def test_verified_installed_version_present(self):
+        """The verified installed version string must appear."""
+        self.assertIn("2.1.185", self.content)
+
+    def test_version_string_format(self):
+        """Verified version must follow the 'X.Y.Z (Claude Code)' format."""
+        self.assertRegex(
+            self.content,
+            r"\d+\.\d+\.\d+ \(Claude Code\)",
+            msg="Version string must match 'X.Y.Z (Claude Code)' format",
+        )
+
+    def test_nodejs_minimum_version_requirement(self):
+        """Node.js 18 minimum version requirement must be documented."""
+        self.assertIn("Node.js 18", self.content)
+
+    def test_nodejs_environment_version_noted(self):
+        """The installed Node.js version (20.20.2) must be documented."""
+        self.assertIn("20.20.2", self.content)
+
+    def test_sudo_warning_present(self):
+        """Warning against using sudo with npm install must be present."""
+        self.assertIn("sudo", self.content)
+        # The instruction is to NOT use sudo; a prohibition must appear.
+        self.assertRegex(
+            self.content,
+            r"[Dd]o not use.*sudo|sudo.*not",
+            msg="A 'do not use sudo' instruction must be present",
+        )
+
+    def test_upgrade_command_present(self):
+        """The upgrade command must be documented."""
+        # Upgrade uses the same install command; verify it is referenced in context.
+        upgrade_pattern = re.search(
+            r"[Uu]pgrade.*npm install -g @anthropic-ai/claude-code@latest",
+            self.content,
+        )
+        self.assertIsNotNone(upgrade_pattern, "Upgrade instruction with npm command must be present")
+
+    def test_claude_version_command_present(self):
+        """'claude --version' must appear in the code block."""
+        self.assertIn("claude --version", self.content)
+
+    def test_installation_section_uses_bash_code_block(self):
+        """The install commands must be wrapped in a bash fenced code block."""
+        self.assertRegex(
+            self.content,
+            r"```bash[\s\S]+?npm install -g @anthropic-ai/claude-code@latest[\s\S]+?```",
+            msg="npm install command must be inside a ```bash ... ``` fenced block",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Motivation

- Provide a local Claude Code CLI installation and document the verified install/upgrade steps for the environment.  
- Add an explicit, canonical source-of-truth for K Fitness Center business data, pricing, safety rules, and marketing structure so the assistant can reference consistent facts.  
- Ship a multilingual AI assistant playbook with ready-to-use customer answers, sales scripts, safety guidance, and marketing templates for operational use.

### Description

- Installed the Claude Code CLI globally using `npm install -g @anthropic-ai/claude-code@latest` and validated the executable with `claude --version` (verified `2.1.185`).  
- Expanded `README.md` with a “Business Source of Truth” table, pricing, free classes, services, assistant role, sales style, safety rules, marketing post structure, and a Claude Code installation/maintenance note.  
- Added `docs/assistant-playbook.md` containing a multilingual playbook with opening-hours/pricing templates, quick customer answers, sales closing scripts, safety guardrails, marketing templates, content workflow, and a weekly output calendar.  
- Added `.gitignore` entries to ignore Python bytecode (`__pycache__/` and `*.py[cod]`) and made small wording/capitalization edits to ensure test consistency.

### Testing

- Ran the unit test suite with `python3 -m unittest discover -s tests` and all tests passed.  
- Verified the installed Claude Code binary with `claude --version`, which returned `2.1.185 (Claude Code)`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3794f4a50083338cf5bac5303132a8)