### PR TITLE
Add n8n webhook connection form

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ The landing page now includes an n8n lead/request form. To connect it:
 
 1. In n8n, create a workflow with a **Webhook** trigger.
 2. Set the webhook method to **POST** and copy the production webhook URL.
-3. Open `index.html` and replace `YOUR-N8N-WEBHOOK-URL` in the `data-webhook-url` attribute with your production URL.
-4. Activate the n8n workflow.
-5. Submit the form on the page. The browser sends JSON with `name`, `phone`, `requestType`, `message`, `source`, and `submittedAt` to n8n.
+3. For the local n8n dashboard at <http://localhost:5678/home/workflows>, set the Webhook path to `kfitness-ai-os`. The page is already configured to send to <http://localhost:5678/webhook/kfitness-ai-os>.
+4. If you deploy n8n somewhere else, open `index.html` and replace the `data-webhook-url` value with your production webhook URL.
+5. Activate the n8n workflow.
+6. Submit the form on the page. The browser sends JSON with `name`, `phone`, `requestType`, `message`, `source`, and `submittedAt` to n8n.
 
 Suggested next n8n nodes: Google Sheets/Airtable for lead storage, Telegram or Messenger for staff alerts, and email/SMS for customer follow-up.

--- a/README.md
+++ b/README.md
@@ -9,3 +9,15 @@ python3 -m http.server 4173
 ```
 
 Then open <http://127.0.0.1:4173/index.html>.
+
+## n8n connection
+
+The landing page now includes an n8n lead/request form. To connect it:
+
+1. In n8n, create a workflow with a **Webhook** trigger.
+2. Set the webhook method to **POST** and copy the production webhook URL.
+3. Open `index.html` and replace `YOUR-N8N-WEBHOOK-URL` in the `data-webhook-url` attribute with your production URL.
+4. Activate the n8n workflow.
+5. Submit the form on the page. The browser sends JSON with `name`, `phone`, `requestType`, `message`, `source`, and `submittedAt` to n8n.
+
+Suggested next n8n nodes: Google Sheets/Airtable for lead storage, Telegram or Messenger for staff alerts, and email/SMS for customer follow-up.

--- a/index.html
+++ b/index.html
@@ -241,9 +241,10 @@
       <section class="panel n8n-panel" aria-labelledby="n8n-title">
         <div>
           <h2 id="n8n-title" class="section-ribbon">7. n8n Automation Connection</h2>
-          <p class="n8n-intro">Send new member leads, content requests, and follow-up tasks directly into your n8n workflow.</p>
+          <p class="n8n-intro">Send new member leads, content requests, and follow-up tasks directly into your local n8n AI OS workflow.</p>
+          <a class="n8n-workflows-link" href="http://localhost:5678/home/workflows" target="_blank" rel="noreferrer">Open n8n workflows</a>
         </div>
-        <form class="n8n-form" data-n8n-form data-webhook-url="YOUR-N8N-WEBHOOK-URL" aria-label="Send a request to n8n automation">
+        <form class="n8n-form" data-n8n-form data-webhook-url="http://localhost:5678/webhook/kfitness-ai-os" aria-label="Send a request to n8n automation">
           <label>
             Name
             <input name="name" type="text" placeholder="Customer name" required />
@@ -266,7 +267,7 @@
             <textarea name="message" rows="3" placeholder="Tell n8n what to do next"></textarea>
           </label>
           <button type="submit">Send to n8n</button>
-          <p class="n8n-status" data-n8n-status role="status">Waiting for your n8n webhook URL.</p>
+          <p class="n8n-status" data-n8n-status role="status">Ready to send to http://localhost:5678/webhook/kfitness-ai-os.</p>
         </form>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
       rel="stylesheet"
     />
     <link rel="stylesheet" href="styles.css" />
+    <script src="script.js" defer></script>
   </head>
   <body>
     <main class="poster" aria-label="K Fitness Center automated content creation workflow">
@@ -235,6 +236,38 @@
           <div><b>◎ Data-Driven</b><span>AI optimizes for better results</span></div>
           <div><b>⚙ Scalable</b><span>Works for all platforms and campaigns</span></div>
         </div>
+      </section>
+
+      <section class="panel n8n-panel" aria-labelledby="n8n-title">
+        <div>
+          <h2 id="n8n-title" class="section-ribbon">7. n8n Automation Connection</h2>
+          <p class="n8n-intro">Send new member leads, content requests, and follow-up tasks directly into your n8n workflow.</p>
+        </div>
+        <form class="n8n-form" data-n8n-form data-webhook-url="YOUR-N8N-WEBHOOK-URL" aria-label="Send a request to n8n automation">
+          <label>
+            Name
+            <input name="name" type="text" placeholder="Customer name" required />
+          </label>
+          <label>
+            Phone
+            <input name="phone" type="tel" placeholder="09xxxxxxxxx" required />
+          </label>
+          <label>
+            Request Type
+            <select name="requestType" required>
+              <option value="membership">Membership inquiry</option>
+              <option value="private-coach">Private coach</option>
+              <option value="content-request">Content request</option>
+              <option value="follow-up">Follow-up task</option>
+            </select>
+          </label>
+          <label>
+            Message
+            <textarea name="message" rows="3" placeholder="Tell n8n what to do next"></textarea>
+          </label>
+          <button type="submit">Send to n8n</button>
+          <p class="n8n-status" data-n8n-status role="status">Waiting for your n8n webhook URL.</p>
+        </form>
       </section>
 
       <footer class="poster-footer">

--- a/script.js
+++ b/script.js
@@ -1,0 +1,42 @@
+const form = document.querySelector('[data-n8n-form]');
+const statusEl = document.querySelector('[data-n8n-status]');
+
+const N8N_WEBHOOK_URL = form?.dataset.webhookUrl || '';
+
+function setStatus(message, type = 'info') {
+  if (!statusEl) return;
+  statusEl.textContent = message;
+  statusEl.dataset.state = type;
+}
+
+form?.addEventListener('submit', async (event) => {
+  event.preventDefault();
+
+  if (!N8N_WEBHOOK_URL || N8N_WEBHOOK_URL.includes('YOUR-N8N-WEBHOOK-URL')) {
+    setStatus('Please add your n8n production webhook URL in index.html first.', 'warning');
+    return;
+  }
+
+  const payload = Object.fromEntries(new FormData(form).entries());
+  payload.source = 'K Fitness Center landing page';
+  payload.submittedAt = new Date().toISOString();
+
+  setStatus('Sending to n8n workflow...', 'info');
+
+  try {
+    const response = await fetch(N8N_WEBHOOK_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      throw new Error(`n8n returned ${response.status}`);
+    }
+
+    form.reset();
+    setStatus('Success! Your request was sent to n8n automation.', 'success');
+  } catch (error) {
+    setStatus(`Could not send to n8n: ${error.message}`, 'error');
+  }
+});

--- a/script.js
+++ b/script.js
@@ -12,8 +12,8 @@ function setStatus(message, type = 'info') {
 form?.addEventListener('submit', async (event) => {
   event.preventDefault();
 
-  if (!N8N_WEBHOOK_URL || N8N_WEBHOOK_URL.includes('YOUR-N8N-WEBHOOK-URL')) {
-    setStatus('Please add your n8n production webhook URL in index.html first.', 'warning');
+  if (!N8N_WEBHOOK_URL) {
+    setStatus('Please add your n8n webhook URL in index.html first.', 'warning');
     return;
   }
 
@@ -37,6 +37,6 @@ form?.addEventListener('submit', async (event) => {
     form.reset();
     setStatus('Success! Your request was sent to n8n automation.', 'success');
   } catch (error) {
-    setStatus(`Could not send to n8n: ${error.message}`, 'error');
+    setStatus(`Could not send to n8n at ${N8N_WEBHOOK_URL}. Make sure your local workflow is active: ${error.message}`, 'error');
   }
 });

--- a/styles.css
+++ b/styles.css
@@ -159,3 +159,70 @@ td:first-child { font-weight: 900; text-transform: uppercase; }
   .insight-bar { grid-template-columns: 1fr; }
   .insight-bar span { border-right: 0; border-bottom: 1px solid var(--line); }
 }
+
+.n8n-panel {
+  margin-top: 16px;
+  overflow: hidden;
+}
+
+.n8n-intro {
+  margin: 18px 26px 0;
+  font-weight: 800;
+}
+
+.n8n-form {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 14px;
+  padding: 20px 26px 24px;
+}
+
+.n8n-form label {
+  display: grid;
+  gap: 7px;
+  font-weight: 900;
+  text-transform: uppercase;
+  font-size: 12px;
+}
+
+.n8n-form input,
+.n8n-form select,
+.n8n-form textarea {
+  width: 100%;
+  border: 1px solid #bfc2c0;
+  border-radius: 10px;
+  padding: 12px 13px;
+  background: #fff;
+  color: var(--ink);
+  font: 600 14px/1.3 Inter, Arial, sans-serif;
+}
+
+.n8n-form textarea { resize: vertical; }
+
+.n8n-form button {
+  align-self: end;
+  border: 0;
+  border-radius: 12px;
+  padding: 14px 18px;
+  background: linear-gradient(90deg, var(--gold), var(--gold-dark));
+  color: #111;
+  font-weight: 900;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.n8n-status {
+  grid-column: span 3;
+  align-self: center;
+  margin: 0;
+  font-weight: 800;
+}
+
+.n8n-status[data-state="success"] { color: #126c2f; }
+.n8n-status[data-state="warning"] { color: #8a5a00; }
+.n8n-status[data-state="error"] { color: #a02121; }
+
+@media (max-width: 1100px) {
+  .n8n-form { grid-template-columns: 1fr; }
+  .n8n-status { grid-column: auto; }
+}

--- a/styles.css
+++ b/styles.css
@@ -226,3 +226,11 @@ td:first-child { font-weight: 900; text-transform: uppercase; }
   .n8n-form { grid-template-columns: 1fr; }
   .n8n-status { grid-column: auto; }
 }
+
+.n8n-workflows-link {
+  display: inline-flex;
+  margin: 12px 26px 0;
+  color: #111;
+  font-weight: 900;
+  text-transform: uppercase;
+}


### PR DESCRIPTION
### Motivation
- Provide a simple way for the landing page to send leads, content requests, and follow-up tasks into an n8n automation workflow. 
- Make it easy for operators to connect the static page to production automation without adding backend code.

### Description
- Added a new "n8n Automation Connection" panel to `index.html` containing a form with `name`, `phone`, `requestType`, `message`, and a `data-webhook-url` attribute for the production webhook. 
- Introduced `script.js` with client-side logic that validates the webhook URL, builds a JSON payload (`name`, `phone`, `requestType`, `message`, `source`, `submittedAt`), POSTs it to the configured n8n webhook, and updates an on-page status element. 
- Extended `styles.css` with responsive styles for the new n8n panel, form inputs, button, and status states. 
- Updated `README.md` with brief setup instructions for creating and wiring an n8n Webhook trigger to the page.

### Testing
- Verified the updated HTML parses with Python's `html.parser` successfully. 
- Confirmed the static server can serve the page by running `python3 -m http.server 4173` and fetching the page with `curl -I http://127.0.0.1:4173/index.html`. 
- Ran the test suite with `python3 -m unittest discover -s tests`, which executed 181 tests but failed with `failures=62` and `errors=113`; the failures/errors are caused by tests that expect `docs/assistant-playbook.md` and additional README playbook/business content that are outside the scope of this n8n integration change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a419f149ecc833395db8f923c938d38)