### PR TITLE
Add K Fitness Center assistant playbook, content workflow, and brief generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,63 @@
-# K-Fitness-Center
-Welcome to K Fitness Center 
+# K Fitness Center
+
+K Fitness Center is a gym in Shwe Kokko Myain, Myawaddy. This repository stores the official AI assistant knowledge base, customer-service playbooks, and marketing content system for K Fitness Center.
+
+## Official AI Assistant Role
+
+The AI assistant represents K Fitness Center in customer conversations and marketing workflows. It should:
+
+- Answer customer questions about prices, opening hours, services, location, promotions, and training.
+- Generate gym marketing posts for Facebook, Telegram, TikTok, and YouTube.
+- Support gym management, customer service, and sales closing.
+- Reply in the same language as the customer: Myanmar, English, or Chinese. If the customer mixes Myanmar and English, reply in Myanmar-English bilingual style.
+
+## Business Source of Truth
+
+| Item | Details |
+| --- | --- |
+| Name | K Fitness Center |
+| Location | Shwe Kokko Myain, Myawaddy |
+| Google Map | https://maps.app.goo.gl/pDefLUxTmSoZ3RB18?g_st=ipc |
+| Phone | 09966766466, 09676003533, 09675844933 |
+| Opening Hours | Monday to Saturday, 6:00 AM to 1:00 AM |
+| Sunday | Closed |
+| Single Visit | 250฿ |
+| Monthly Plan | 1700฿ + 300฿ membership fee |
+| 3-Month Plan | 5000฿ + 1 month free |
+| 6-Month Plan | 10000฿ + 3 months free |
+| Private Coach | +2000฿ per person |
+| Pickup / Drop Service | +2000฿ |
+| Free Group Classes | Aerobics, Zumba, Trampoline, Step Board |
+| Services | Muscle gain, fat loss, CrossFit, Aerobics, Zumba, private coach, nutrition guidance, pickup service |
+
+## Sales Style
+
+Use clear, short, confident replies. When selling or closing a customer, always include a contact number or next action.
+
+Recommended sales flow:
+
+1. Answer the question directly.
+2. Highlight the customer benefit.
+3. Recommend the best plan based on the customer goal.
+4. Ask for the next action, such as visiting the gym, calling, or messaging the page.
+
+## Safety Rules
+
+- Do not provide medical diagnosis.
+- Do not promise exact weight-loss results.
+- If a customer mentions pain, injury, dizziness, illness, pregnancy, medication, or any health problem, advise them to consult a qualified medical professional before training.
+- Fitness guidance should be general and safe, not a replacement for professional medical advice.
+
+## Marketing Post Structure
+
+For Facebook, Telegram, TikTok, and YouTube posts, use this structure:
+
+1. **Question** — Start with a question that matches the customer pain point.
+2. **Emotion** — Show you understand the customer goal or struggle.
+3. **Trust** — Mention K Fitness Center services, group classes, coaches, or community.
+4. **Offer** — Present the relevant price, promotion, or service.
+5. **Close** — Add phone numbers, map link, or a direct call to action.
+
+See [`docs/assistant-playbook.md`](docs/assistant-playbook.md) for multilingual reply templates, sales scripts, and marketing examples.
+
+See [`docs/automated-content-workflow.md`](docs/automated-content-workflow.md) and [`data/content-workflow.json`](data/content-workflow.json) for the poster-style automated content creation workflow, feedback loop, tool stack, output calendar, and publishing checklist. Use [`scripts/generate_content_workflow.py`](scripts/generate_content_workflow.py) to create a step-by-step production brief, with an example output in [`output/k-fitness-content-brief.md`](output/k-fitness-content-brief.md).

--- a/data/content-workflow.json
+++ b/data/content-workflow.json
@@ -1,0 +1,72 @@
+{
+  "system_name": "K Fitness Center - Automated Content Creation System",
+  "tagline": "Automatically thinking topics, generating content, creating videos and images, publishing, and learning from performance.",
+  "workflow": [
+    {
+      "step": 1,
+      "name": "Topic Ideas",
+      "module": "AI Idea Generator",
+      "tasks": ["Trend analysis", "User interests", "Fitness calendar", "FAQs", "Surveys"],
+      "output": "Weekly content ideas"
+    },
+    {
+      "step": 2,
+      "name": "Content Planning",
+      "module": "AI Planner",
+      "tasks": ["Topic selection", "Content type", "Format: video or image", "Posting schedule"],
+      "output": "Approved content plan"
+    },
+    {
+      "step": 3,
+      "name": "Content Generation",
+      "module": "AI Content Writer",
+      "tasks": ["Script", "Title", "Description", "Key points", "Call to action"],
+      "output": "Ready-to-review copy and script"
+    },
+    {
+      "step": 4,
+      "name": "Image Generation",
+      "module": "AI Image Generator",
+      "tasks": ["Poster", "Thumbnail", "Infographic", "Exercise guide", "Branded visuals"],
+      "output": "Image asset brief or generated image"
+    },
+    {
+      "step": 5,
+      "name": "Video Generation",
+      "module": "AI Video Generator",
+      "tasks": ["Video script", "Voice over", "B-roll or stock clips", "Subtitles", "Effects"],
+      "output": "Video production brief or generated video"
+    },
+    {
+      "step": 6,
+      "name": "Publish and Distribute",
+      "module": "Auto Post System",
+      "tasks": ["Social media", "Website", "Email or newsletter"],
+      "output": "Published content"
+    }
+  ],
+  "feedback_loop": [
+    "Analytics and insights",
+    "User engagement",
+    "Content performance",
+    "AI learning and improvement",
+    "Auto optimization"
+  ],
+  "weekly_calendar": [
+    { "day": "Monday", "content_type": "Infographic", "topic": "Benefits of strength training", "channel": "Instagram / Facebook" },
+    { "day": "Tuesday", "content_type": "Short video", "topic": "HIIT workout in 15 minutes", "channel": "TikTok / Reels / Shorts" },
+    { "day": "Wednesday", "content_type": "Image post", "topic": "Healthy meal ideas", "channel": "Instagram / Facebook" },
+    { "day": "Thursday", "content_type": "Long video", "topic": "Beginner workout guide", "channel": "YouTube" },
+    { "day": "Friday", "content_type": "Tips post", "topic": "How to stay motivated", "channel": "Instagram / Facebook" },
+    { "day": "Saturday", "content_type": "Q&A / Poll", "topic": "Ask your trainer", "channel": "Instagram Stories / Telegram" },
+    { "day": "Sunday", "content_type": "Motivation post", "topic": "Be stronger than your excuses", "channel": "Instagram / Facebook" }
+  ],
+  "publishing_checklist": [
+    "Follow Question > Emotion > Trust > Offer > Close.",
+    "Include contact numbers when selling.",
+    "Include location or map when inviting customers to visit.",
+    "Verify prices and promotions against the source of truth.",
+    "Do not include medical diagnosis or guaranteed weight-loss results.",
+    "Advise customers with pain, injury, dizziness, or health issues to consult a qualified medical professional."
+  ]
+}

--- a/docs/assistant-playbook.md
+++ b/docs/assistant-playbook.md
@@ -1,0 +1,209 @@
+# K Fitness Center AI Assistant Playbook
+
+## Core Identity
+
+You are the official AI assistant for K Fitness Center in Shwe Kokko Myain, Myawaddy. Your job is to answer quickly, sell confidently, protect customer safety, and help the gym create marketing content.
+
+## Language Policy
+
+Reply in the same language the customer uses:
+
+- Myanmar customer: reply in Myanmar.
+- English customer: reply in English.
+- Chinese customer: reply in Chinese.
+- Mixed Myanmar-English customer: reply in Myanmar-English bilingual style.
+
+Keep replies short and natural for chat. Use friendly confidence, not long explanations, unless the customer asks for details.
+
+## Quick Customer Answers
+
+### Opening Hours
+
+**English**
+
+K Fitness Center is open Monday to Saturday from 6:00 AM to 1:00 AM. Sunday is closed. You can visit us at Shwe Kokko Myain, Myawaddy.
+
+**Myanmar**
+
+K Fitness Center က Monday to Saturday မနက် 6:00 ကနေ ည 1:00 အထိ ဖွင့်ပါတယ်။ Sunday ပိတ်ပါတယ်။ Shwe Kokko Myain, Myawaddy မှာ လာကစားလို့ရပါတယ်။
+
+**Chinese**
+
+K Fitness Center 周一到周六早上 6:00 到凌晨 1:00 营业，周日休息。地址在 Shwe Kokko Myain, Myawaddy。
+
+### Prices
+
+**English**
+
+Our prices are:
+
+- Single visit: 250฿
+- Monthly: 1700฿ + 300฿ membership fee
+- 3 months: 5000฿ + 1 month free
+- 6 months: 10000฿ + 3 months free
+- Private coach: +2000฿ per person
+- Pickup/drop service: +2000฿
+
+For the best value, the 3-month and 6-month plans include free extra months. Call 09966766466, 09676003533, or 09675844933 to join.
+
+**Myanmar**
+
+ဈေးနှုန်းတွေကတော့:
+
+- တစ်ခါကစား: 250฿
+- 1 လ: 1700฿ + membership fee 300฿
+- 3 လ: 5000฿ + 1 လ free
+- 6 လ: 10000฿ + 3 လ free
+- Private coach: တစ်ယောက် +2000฿
+- Pickup/drop service: +2000฿
+
+တန်တာရွေးချင်ရင် 3 လ plan နဲ့ 6 လ plan တွေက free month ပါပါတယ်။ Join ချင်ရင် 09966766466, 09676003533, 09675844933 ကိုဆက်သွယ်နိုင်ပါတယ်။
+
+**Chinese**
+
+价格如下：
+
+- 单次：250฿
+- 月卡：1700฿ + 300฿ 会员费
+- 3 个月：5000฿ + 免费 1 个月
+- 6 个月：10000฿ + 免费 3 个月
+- 私教：每人 +2000฿
+- 接送服务：+2000฿
+
+最划算的是 3 个月和 6 个月配套，因为有免费月份。报名请联系 09966766466, 09676003533, 09675844933。
+
+### Services
+
+**English**
+
+We support muscle gain, fat loss, CrossFit, Aerobics, Zumba, private coaching, nutrition guidance, and pickup service. Free group classes include Aerobics, Zumba, Trampoline, and Step Board.
+
+**Myanmar**
+
+K Fitness Center မှာ muscle gain, fat loss, CrossFit, Aerobics, Zumba, private coach, nutrition guidance နဲ့ pickup service တွေရှိပါတယ်။ Free group classes တွေက Aerobics, Zumba, Trampoline, Step Board ပါ။
+
+**Chinese**
+
+我们提供增肌、减脂、CrossFit、有氧操、Zumba、私教、营养建议和接送服务。免费团课包括 Aerobics、Zumba、Trampoline 和 Step Board。
+
+### Location
+
+**English**
+
+We are located at Shwe Kokko Myain, Myawaddy. Google Map: https://maps.app.goo.gl/pDefLUxTmSoZ3RB18?g_st=ipc
+
+**Myanmar**
+
+K Fitness Center က Shwe Kokko Myain, Myawaddy မှာရှိပါတယ်။ Google Map: https://maps.app.goo.gl/pDefLUxTmSoZ3RB18?g_st=ipc
+
+**Chinese**
+
+我们在 Shwe Kokko Myain, Myawaddy。Google 地图：https://maps.app.goo.gl/pDefLUxTmSoZ3RB18?g_st=ipc
+
+## Sales Closing Scripts
+
+### New Customer Asking Price
+
+**Myanmar-English bilingual**
+
+အခုစပြီး gym ကစားမယ်ဆို Monthly plan က အဆင်ပြေပါတယ် — 1700฿ + membership 300฿ ပါ။ Long-term result လိုချင်ရင် 3 months plan က 5000฿ နဲ့ 1 month free ပါလို့ ပိုတန်ပါတယ်။ ဒီနေ့လာကြည့်မလား? Location: https://maps.app.goo.gl/pDefLUxTmSoZ3RB18?g_st=ipc Phone: 09966766466, 09676003533, 09675844933
+
+### Fat Loss Customer
+
+**English**
+
+Yes, we can help with fat loss through training, group classes, and nutrition guidance. Results depend on consistency, food, and body condition, so we do not promise exact kg loss. If you want, start with the monthly plan or choose a private coach for closer guidance. Call 09966766466, 09676003533, or 09675844933.
+
+### Muscle Gain Customer
+
+**English**
+
+For muscle gain, we recommend strength training, progressive overload, enough protein, and consistent rest. K Fitness Center can support you with equipment, private coaching, and nutrition guidance. The 3-month plan is a strong choice because it includes 1 free month. Message us or call 09966766466 to start.
+
+### Customer With Pain or Injury
+
+**English**
+
+If you have pain or injury, please consult a medical professional before training. After you are cleared to exercise, our coach can guide you with safe beginner-friendly workouts.
+
+**Myanmar**
+
+နာကျင်မှု၊ ထိခိုက်ဒဏ်ရာ၊ မူးဝေခြင်း၊ ကျန်းမာရေးပြဿနာရှိရင် gym မစခင် ဆရာဝန်/ကျန်းမာရေးပညာရှင်နဲ့ အရင်တိုင်ပင်ပါ။ ကစားလို့ရပြီဆိုမှ coach က safe beginner workout နဲ့ကူညီပေးနိုင်ပါတယ်။
+
+## Marketing Content Templates
+
+### Facebook / Telegram Post
+
+**Question**
+
+Want to get stronger and look better this month?
+
+**Emotion**
+
+Starting is hard, but staying the same is harder.
+
+**Trust**
+
+At K Fitness Center, you can train for muscle gain, fat loss, CrossFit, Aerobics, Zumba, and more. Free group classes include Aerobics, Zumba, Trampoline, and Step Board.
+
+**Offer**
+
+Monthly plan: 1700฿ + 300฿ membership fee. 3 months: 5000฿ + 1 month free. 6 months: 10000฿ + 3 months free.
+
+**Close**
+
+Visit us at Shwe Kokko Myain, Myawaddy. Call 09966766466, 09676003533, or 09675844933. Map: https://maps.app.goo.gl/pDefLUxTmSoZ3RB18?g_st=ipc
+
+### TikTok / Reels Short Video Script
+
+**Hook**
+
+Still waiting for the perfect day to start gym?
+
+**Body**
+
+Start today at K Fitness Center. Train for fat loss, muscle gain, CrossFit, Zumba, Aerobics, and more. Beginner friendly. Coach support available.
+
+**Offer**
+
+3 months plan: 5000฿ + 1 month free. 6 months plan: 10000฿ + 3 months free.
+
+**Call to Action**
+
+Come to Shwe Kokko Myain, Myawaddy, or call 09966766466.
+
+### YouTube Video Idea
+
+**Title**
+
+Beginner Gym Guide at K Fitness Center | Fat Loss & Muscle Gain Tips
+
+**Description**
+
+Learn how beginners can start training safely at K Fitness Center in Shwe Kokko Myain, Myawaddy. We explain simple workout habits, group classes, private coaching, nutrition guidance, and membership plans. For health problems, pain, injury, or dizziness, consult a medical professional before training.
+
+**Call to Action**
+
+Join K Fitness Center today. Call 09966766466, 09676003533, or 09675844933.
+
+## Content Creation Workflow
+
+1. Topic ideas: trends, customer questions, fitness calendar, surveys.
+2. Content planning: select topic, format, posting schedule, and platform.
+3. Content generation: script, title, description, key points, and call to action.
+4. Image generation: poster, thumbnail, infographic, exercise guide, branded visual.
+5. Video generation: short script, voice-over, b-roll plan, subtitles, and effects.
+6. Publish and distribute: Facebook, Telegram, TikTok, YouTube, website, and newsletter.
+7. Review performance: engagement, inquiries, signups, and customer feedback.
+
+## Weekly Automated Output Calendar
+
+| Day | Content Type | Topic Example | Channel |
+| --- | --- | --- | --- |
+| Monday | Infographic | Benefits of strength training | Facebook / Instagram |
+| Tuesday | Short video | 15-minute HIIT workout | TikTok / Reels / Shorts |
+| Wednesday | Image post | Healthy meal ideas | Facebook / Instagram |
+| Thursday | Long video | Beginner workout guide | YouTube |
+| Friday | Tips post | How to stay motivated | Facebook / Instagram |
+| Saturday | Q&A / Poll | Ask your trainer | Stories / Telegram |
+| Sunday | Motivation post | Be stronger than your excuses | Facebook / Instagram |

--- a/docs/automated-content-workflow.md
+++ b/docs/automated-content-workflow.md
@@ -1,0 +1,186 @@
+# K Fitness Center — Automated Content Creation System
+
+This workflow follows the requested poster structure: the system automatically thinks of topics, plans content, generates captions/scripts, creates image and video briefs, publishes to channels, and learns from feedback.
+
+## 1. Automated Content Creation Workflow
+
+```mermaid
+flowchart LR
+    A[1. Topic Ideas\nAI Idea Generator\n- Trend analysis\n- User interests\n- Fitness calendar\n- FAQs and surveys] --> B[2. Content Planning\nAI Planner\n- Topic selection\n- Content type\n- Format: video/image\n- Posting schedule]
+    B --> C[3. Content Generation\nAI Content Writer\n- Script/title\n- Description\n- Key points\n- CTA]
+    C --> D[4. Image Generation\nAI Image Generator\n- Poster/thumbnail\n- Infographic\n- Exercise guide\n- Branded visuals]
+    D --> E[5. Video Generation\nAI Video Generator\n- Video script\n- Voice over\n- B-roll/stock clips\n- Subtitles/effects]
+    E --> F[6. Publish & Distribute\nAuto Post System\n- Facebook/Instagram\n- TikTok/YouTube\n- Website\n- Email/newsletter]
+
+    F --> G[Feedback & Performance Data]
+    G --> A
+    G --> B
+    G --> C
+    G --> E
+    G --> H[Analytics & Insights]
+    G --> I[User Engagement]
+    G --> J[Content Performance]
+    G --> K[AI Learning & Improvement]
+    G --> L[Auto Optimization]
+```
+
+### Workflow Stages
+
+| Step | Module | Inputs | Output | Human Approval |
+| --- | --- | --- | --- | --- |
+| 1 | Topic Ideas | Trends, FAQs, gym promotions, class calendar, customer comments | 10-20 weekly content ideas | Optional |
+| 2 | Content Planning | Topic list, platform, target customer, campaign goal | Weekly content plan and post schedule | Required before production |
+| 3 | Content Generation | Approved topic and K Fitness source of truth | Captions, scripts, titles, descriptions, CTAs | Required for offers/prices |
+| 4 | Image Generation | Caption, brand colors, image format, exercise topic | Poster, thumbnail, infographic, exercise guide brief | Required before publishing |
+| 5 | Video Generation | Script, visual plan, voice-over direction | Reels/Shorts/TikTok script, subtitles, shot list | Required before publishing |
+| 6 | Publish & Distribute | Final assets, caption, hashtags, channel schedule | Published posts across social channels | Required for paid ads |
+| 7 | Feedback Loop | Reach, views, comments, messages, signups | Improved topics, hooks, offers, and schedules | Weekly review |
+
+
+## Step-by-Step Execution System
+
+Use this system exactly one stage at a time. Do not skip approval checkpoints when prices, promotions, medical-safety wording, or paid ads are involved.
+
+### Step 1: Topic Ideas — AI Idea Generator
+
+1. Collect inputs from trend analysis, user interests, the fitness calendar, FAQs, and surveys.
+2. Create 10-20 topic ideas for the week.
+3. Tag each idea by customer goal: fat loss, muscle gain, beginner training, group class, promotion, or motivation.
+4. Pick the strongest idea for the next post.
+
+**Output:** one approved topic plus backup topics.
+
+### Step 2: Content Planning — AI Planner
+
+1. Choose the platform: Facebook, Instagram, Telegram, TikTok, YouTube, website, or email.
+2. Choose the content type: infographic, image post, short video, long video, Q&A, poll, or motivation post.
+3. Choose the format: 9:16 vertical video, 1:1 square image, 16:9 YouTube video, or text-only message.
+4. Set the publish date and time.
+
+**Output:** approved content plan with platform, format, target customer, and schedule.
+
+### Step 3: Content Generation — AI Content Writer
+
+1. Write the caption or script using **Question > Emotion > Trust > Offer > Close**.
+2. Include K Fitness Center facts only from the source of truth.
+3. Add the correct phone numbers and map link when selling or inviting customers to visit.
+4. Check safety: no medical diagnosis and no exact weight-loss promise.
+
+**Output:** ready-to-review caption, title, description, key points, hashtags, and CTA.
+
+### Step 4: Image Generation — AI Image Generator
+
+1. Create a poster, thumbnail, infographic, exercise guide, or branded visual brief.
+2. Use K Fitness brand style: black, yellow, white, strong gym visuals, clear headline, and readable CTA.
+3. Add only safe exercise cues and avoid unrealistic body-transformation claims.
+4. Export the correct size for the target platform.
+
+**Output:** final image asset or image-generation prompt ready for approval.
+
+### Step 5: Video Generation — AI Video Generator
+
+1. Convert the approved script into scenes.
+2. Add voice-over text in the customer language: Myanmar, English, Chinese, or Myanmar-English bilingual.
+3. Add B-roll or stock clip directions, subtitles, and effects.
+4. Keep short videos direct: hook in the first 2 seconds, offer before the end, CTA in the final frame.
+
+**Output:** final video asset or video-production brief ready for approval.
+
+### Step 6: Publish & Distribute — Auto Post System
+
+1. Upload the approved asset and caption to the selected channels.
+2. Confirm contact numbers, map link, price, promotion, and CTA before posting.
+3. Publish or schedule the post.
+4. Save the post link and published time for tracking.
+
+**Output:** published or scheduled content with post links.
+
+### Step 7: Feedback & Performance Data
+
+1. Collect analytics and insights: reach, views, watch time, saves, shares, comments, messages, and signups.
+2. Review user engagement and content performance.
+3. Identify what worked: hook, topic, offer, visual, language, or posting time.
+4. Feed the learning back into Step 1, Step 2, Step 3, and Step 5 for auto optimization.
+
+**Output:** next-cycle improvement notes and optimized content ideas.
+
+### Generator Script
+
+Run the local generator to create a complete step-by-step production brief from the workflow data:
+
+```bash
+python3 scripts/generate_content_workflow.py --topic "Beginner workout guide" --platform "Facebook / TikTok / YouTube Shorts" --language "Myanmar-English bilingual"
+```
+
+The generated brief is written to `output/k-fitness-content-brief.md`.
+
+## 2. Content Examples for K Fitness Center
+
+| Example Type | Purpose | Required Elements | Example Topic |
+| --- | --- | --- | --- |
+| Form Example | Collect member goals and preferences | Name, age, goal, experience level, exercise preference, injuries/limitations | Gym knowledge and exercise preference form |
+| Infographic | Teach simple fitness knowledge | 3-5 key facts, bold title, icons, brand footer | General fitness knowledge: consistency, strength training, overload, nutrition, recovery |
+| Exercise Guide Image | Demonstrate one exercise safely | Exercise name, target muscles, steps, sets/reps, safety cue | Dumbbell squat: 3 sets x 12 reps |
+| Video Thumbnail | Attract clicks for long/short videos | Big title, strong body visual, platform icon, K Fitness branding | 5 best exercises for muscle building |
+| Short Video Preview | Drive Reels/TikTok/Shorts engagement | Hook, 3-5 exercise clips, reps, subtitles, CTA | Leg day workout: squat, lunge, leg press, calf raise |
+
+## 3. AI Tools and Technologies
+
+| Function | Tool Options | K Fitness Use |
+| --- | --- | --- |
+| AI Writing | ChatGPT, Claude, Gemini | Captions, scripts, titles, comments, sales replies |
+| Image Generation | DALL·E, Midjourney, Leonardo AI | Posters, thumbnails, infographics, branded visuals |
+| Video Generation | Pictory, Synthesia, Runway ML | Reels, Shorts, TikTok videos, YouTube intros |
+| Voice Over | ElevenLabs, Murf AI | Myanmar, English, or Chinese voice-over drafts |
+| Automation | Make.com, Zapier, n8n | Move approved content into posting queues |
+| Analytics | Google Analytics, Meta Insights, platform analytics | Track reach, engagement, messages, and signups |
+
+## 4. Automation Process Flow
+
+1. **Trigger** — Start by schedule, event, promotion, or manual request.
+2. **AI topic research and idea generation** — Generate topics from trends, customer FAQs, fitness calendar, and promotions.
+3. **Content planning and approval** — Choose platform, format, target customer, and publish date.
+4. **AI content creation** — Produce text, image brief, video script, subtitle plan, hashtags, and CTA.
+5. **Review and auto optimization** — Check accuracy, safety, price details, language, and sales strength.
+6. **Auto publish and distribution** — Send approved content to Facebook, Instagram, Telegram, TikTok, YouTube, website, or email.
+7. **Performance tracking and AI learning** — Record performance and improve the next content cycle.
+
+## 5. Automated Output Calendar
+
+| Day | Content Type | Topic Example | Channel |
+| --- | --- | --- | --- |
+| Monday | Infographic | Benefits of strength training | Instagram / Facebook |
+| Tuesday | Short video | HIIT workout in 15 minutes | TikTok / Reels / Shorts |
+| Wednesday | Image post | Healthy meal ideas | Instagram / Facebook |
+| Thursday | Long video | Beginner workout guide | YouTube |
+| Friday | Tips post | How to stay motivated | Instagram / Facebook |
+| Saturday | Q&A / Poll | Ask your trainer | Instagram Stories / Telegram |
+| Sunday | Motivation post | Be stronger than your excuses | Instagram / Facebook |
+
+## 6. Benefits for K Fitness Center
+
+| Benefit | Result |
+| --- | --- |
+| Save time | 100% structured content creation process |
+| Consistent | Daily content without missing planning steps |
+| Engage more | More follower interaction and member engagement |
+| Build authority | Educate and inspire customers before they visit |
+| Data-driven | Optimize topics, offers, and hooks using performance data |
+| Scalable | Works for Facebook, Instagram, Telegram, TikTok, YouTube, website, and campaigns |
+
+## Publishing Checklist
+
+Before publishing any post, confirm:
+
+- The caption follows **Question > Emotion > Trust > Offer > Close**.
+- Contact numbers are included when the post is selling: 09966766466, 09676003533, 09675844933.
+- Location or map is included when inviting customers to visit: https://maps.app.goo.gl/pDefLUxTmSoZ3RB18?g_st=ipc.
+- Prices and promotions match the business source of truth.
+- No medical diagnosis or guaranteed weight-loss result is included.
+- Any pain, injury, dizziness, or health issue content advises consulting a qualified medical professional.
+
+## Brand Closing Line
+
+**Smart content. Stronger community. Better results.**
+
+**Join us and transform your fitness journey at K Fitness Center.**

--- a/output/k-fitness-content-brief.md
+++ b/output/k-fitness-content-brief.md
@@ -1,0 +1,134 @@
+# K Fitness Center Content Production Brief
+
+Generated: 2026-06-16
+
+Topic: **Beginner workout guide**  
+Platform: **Facebook / TikTok / YouTube Shorts**  
+Language: **Myanmar-English bilingual**
+
+## Business Source of Truth
+
+- Location: Shwe Kokko Myain, Myawaddy
+- Google Map: https://maps.app.goo.gl/pDefLUxTmSoZ3RB18?g_st=ipc
+- Phone: 09966766466, 09676003533, 09675844933
+- Opening: Monday to Saturday, 6:00 AM to 1:00 AM. Sunday closed.
+- Monthly: 1700฿ + 300฿ membership fee
+- 3 months: 5000฿ + 1 month free
+- 6 months: 10000฿ + 3 months free
+
+## Step 1 — Topic Ideas (AI Idea Generator)
+
+Tasks:
+- Trend analysis
+- User interests
+- Fitness calendar
+- FAQs
+- Surveys
+
+Output to create:
+- Main topic: Beginner workout guide
+- 3 alternative hooks:
+  1. Want better results but do not know where to start?
+  2. Start training today, not next month.
+  3. Build strength, burn fat, and stay consistent at K Fitness Center.
+
+## Step 2 — Content Planning (AI Planner)
+
+Tasks:
+- Topic selection
+- Content type
+- Format: video or image
+- Posting schedule
+
+Approved plan:
+- Content type: Short video + image poster
+- Format: Vertical 9:16 for TikTok/Reels/Shorts, square 1:1 for Facebook/Instagram
+- Target customer: Beginner or returning gym customer in Shwe Kokko / Myawaddy
+- Posting time: Evening after work, or morning before gym rush
+
+## Step 3 — Content Generation (AI Content Writer)
+
+Tasks:
+- Script
+- Title
+- Description
+- Key points
+- Call to action
+
+Caption formula: **Question > Emotion > Trust > Offer > Close**
+
+Draft caption:
+> Want to start your fitness journey but not sure what to do first?  
+> Starting alone can feel hard, but K Fitness Center makes it simple.  
+> Train with equipment, free group classes, nutrition guidance, and coach support.  
+> Monthly plan: 1700฿ + 300฿ membership fee. 3 months: 5000฿ + 1 month free. 6 months: 10000฿ + 3 months free.  
+> Visit Shwe Kokko Myain, Myawaddy or call 09966766466, 09676003533, 09675844933. Map: https://maps.app.goo.gl/pDefLUxTmSoZ3RB18?g_st=ipc
+
+## Step 4 — Image Generation (AI Image Generator)
+
+Tasks:
+- Poster
+- Thumbnail
+- Infographic
+- Exercise guide
+- Branded visuals
+
+Image brief:
+- Brand color: black + yellow + white
+- Main headline: START STRONG AT K FITNESS CENTER
+- Visual: confident gym member, dumbbells, clean gym background
+- Footer: phone numbers + map note
+- Safety: no unrealistic body transformation promise
+
+## Step 5 — Video Generation (AI Video Generator)
+
+Tasks:
+- Video script
+- Voice over
+- B-roll or stock clips
+- Subtitles
+- Effects
+
+Video script:
+- Scene 1: Hook text on screen — "Still waiting to start gym?"
+- Scene 2: Show equipment and beginner exercise clips
+- Scene 3: Show group class energy: Aerobics, Zumba, Trampoline, Step Board
+- Scene 4: Show offer: monthly, 3-month, and 6-month plans
+- Scene 5: CTA: "Message or call K Fitness Center today"
+
+## Step 6 — Publish and Distribute (Auto Post System)
+
+Tasks:
+- Social media
+- Website
+- Email or newsletter
+
+Publishing plan:
+- Facebook/Instagram: poster + full caption
+- TikTok/Reels/Shorts: 15-30 second vertical video
+- Telegram: short caption + poster + phone numbers
+- YouTube: Shorts version first; long video can follow if engagement is high
+
+## Step 7 — Feedback & Performance Data
+
+Track:
+- Analytics and insights
+- User engagement
+- Content performance
+- AI learning and improvement
+- Auto optimization
+
+Weekly improvement rules:
+- If comments ask about price, make the next post price-focused.
+- If video watch time drops early, make the first 2 seconds stronger.
+- If messages increase after showing promotions, repeat the offer with a new visual.
+- If health/injury comments appear, reply safely and recommend medical consultation.
+
+## Final Publishing Checklist
+
+- Follow Question > Emotion > Trust > Offer > Close.
+- Include contact numbers when selling.
+- Include location or map when inviting customers to visit.
+- Verify prices and promotions against the source of truth.
+- Do not include medical diagnosis or guaranteed weight-loss results.
+- Advise customers with pain, injury, dizziness, or health issues to consult a qualified medical professional.

--- a/scripts/generate_content_workflow.py
+++ b/scripts/generate_content_workflow.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Generate a step-by-step K Fitness Center content workflow brief.
+
+This script turns the poster workflow in data/content-workflow.json into a
+ready-to-review content production brief. It does not call external AI services;
+it prepares the exact step-by-step inputs, prompts, and outputs that staff or an
+automation tool can pass into writing, image, video, and publishing systems.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import date
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_DATA = ROOT / "data" / "content-workflow.json"
+DEFAULT_OUTPUT = ROOT / "output" / "k-fitness-content-brief.md"
+
+BUSINESS = {
+    "name": "K Fitness Center",
+    "location": "Shwe Kokko Myain, Myawaddy",
+    "map": "https://maps.app.goo.gl/pDefLUxTmSoZ3RB18?g_st=ipc",
+    "phones": "09966766466, 09676003533, 09675844933",
+    "hours": "Monday to Saturday, 6:00 AM to 1:00 AM. Sunday closed.",
+    "monthly": "1700฿ + 300฿ membership fee",
+    "three_months": "5000฿ + 1 month free",
+    "six_months": "10000฿ + 3 months free",
+}
+
+
+def load_workflow(path: Path) -> dict:
+    with path.open(encoding="utf-8") as file:
+        return json.load(file)
+
+
+def bullet_list(items: list[str]) -> str:
+    return "\n".join(f"- {item}" for item in items)
+
+
+def render_brief(workflow: dict, topic: str, platform: str, language: str) -> str:
+    steps = workflow["workflow"]
+    feedback = workflow["feedback_loop"]
+    checklist = workflow["publishing_checklist"]
+
+    lines = [
+        f"# {BUSINESS['name']} Content Production Brief",
+        "",
+        f"Generated: {date.today().isoformat()}",
+        "",
+        f"Topic: **{topic}**  ",
+        f"Platform: **{platform}**  ",
+        f"Language: **{language}**",
+        "",
+        "## Business Source of Truth",
+        "",
+        f"- Location: {BUSINESS['location']}",
+        f"- Google Map: {BUSINESS['map']}",
+        f"- Phone: {BUSINESS['phones']}",
+        f"- Opening: {BUSINESS['hours']}",
+        f"- Monthly: {BUSINESS['monthly']}",
+        f"- 3 months: {BUSINESS['three_months']}",
+        f"- 6 months: {BUSINESS['six_months']}",
+        "",
+        f"## Step 1 — {steps[0]['name']} ({steps[0]['module']})",
+        "",
+        "Tasks:",
+        bullet_list(steps[0]["tasks"]),
+        "",
+        "Output to create:",
+        f"- Main topic: {topic}",
+        "- 3 alternative hooks:",
+        "  1. Want better results but do not know where to start?",
+        "  2. Start training today, not next month.",
+        "  3. Build strength, burn fat, and stay consistent at K Fitness Center.",
+        "",
+        f"## Step 2 — {steps[1]['name']} ({steps[1]['module']})",
+        "",
+        "Tasks:",
+        bullet_list(steps[1]["tasks"]),
+        "",
+        "Approved plan:",
+        "- Content type: Short video + image poster",
+        "- Format: Vertical 9:16 for TikTok/Reels/Shorts, square 1:1 for Facebook/Instagram",
+        "- Target customer: Beginner or returning gym customer in Shwe Kokko / Myawaddy",
+        "- Posting time: Evening after work, or morning before gym rush",
+        "",
+        f"## Step 3 — {steps[2]['name']} ({steps[2]['module']})",
+        "",
+        "Tasks:",
+        bullet_list(steps[2]["tasks"]),
+        "",
+        "Caption formula: **Question > Emotion > Trust > Offer > Close**",
+        "",
+        "Draft caption:",
+        "> Want to start your fitness journey but not sure what to do first?  ",
+        "> Starting alone can feel hard, but K Fitness Center makes it simple.  ",
+        "> Train with equipment, free group classes, nutrition guidance, and coach support.  ",
+        f"> Monthly plan: {BUSINESS['monthly']}. 3 months: {BUSINESS['three_months']}. 6 months: {BUSINESS['six_months']}.  ",
+        f"> Visit {BUSINESS['location']} or call {BUSINESS['phones']}. Map: {BUSINESS['map']}",
+        "",
+        f"## Step 4 — {steps[3]['name']} ({steps[3]['module']})",
+        "",
+        "Tasks:",
+        bullet_list(steps[3]["tasks"]),
+        "",
+        "Image brief:",
+        "- Brand color: black + yellow + white",
+        "- Main headline: START STRONG AT K FITNESS CENTER",
+        "- Visual: confident gym member, dumbbells, clean gym background",
+        "- Footer: phone numbers + map note",
+        "- Safety: no unrealistic body transformation promise",
+        "",
+        f"## Step 5 — {steps[4]['name']} ({steps[4]['module']})",
+        "",
+        "Tasks:",
+        bullet_list(steps[4]["tasks"]),
+        "",
+        "Video script:",
+        "- Scene 1: Hook text on screen — \"Still waiting to start gym?\"",
+        "- Scene 2: Show equipment and beginner exercise clips",
+        "- Scene 3: Show group class energy: Aerobics, Zumba, Trampoline, Step Board",
+        "- Scene 4: Show offer: monthly, 3-month, and 6-month plans",
+        "- Scene 5: CTA: \"Message or call K Fitness Center today\"",
+        "",
+        f"## Step 6 — {steps[5]['name']} ({steps[5]['module']})",
+        "",
+        "Tasks:",
+        bullet_list(steps[5]["tasks"]),
+        "",
+        "Publishing plan:",
+        "- Facebook/Instagram: poster + full caption",
+        "- TikTok/Reels/Shorts: 15-30 second vertical video",
+        "- Telegram: short caption + poster + phone numbers",
+        "- YouTube: Shorts version first; long video can follow if engagement is high",
+        "",
+        "## Step 7 — Feedback & Performance Data",
+        "",
+        "Track:",
+        bullet_list(feedback),
+        "",
+        "Weekly improvement rules:",
+        "- If comments ask about price, make the next post price-focused.",
+        "- If video watch time drops early, make the first 2 seconds stronger.",
+        "- If messages increase after showing promotions, repeat the offer with a new visual.",
+        "- If health/injury comments appear, reply safely and recommend medical consultation.",
+        "",
+        "## Final Publishing Checklist",
+        "",
+        bullet_list(checklist),
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate K Fitness step-by-step content brief")
+    parser.add_argument("--topic", default="Beginner workout guide", help="Content topic")
+    parser.add_argument("--platform", default="Facebook / TikTok / YouTube Shorts", help="Target platform")
+    parser.add_argument("--language", default="Myanmar-English bilingual", help="Output language direction")
+    parser.add_argument("--data", type=Path, default=DEFAULT_DATA, help="Workflow JSON path")
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT, help="Output markdown path")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    workflow = load_workflow(args.data)
+    brief = render_brief(workflow, args.topic, args.platform, args.language)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(brief, encoding="utf-8")
+    print(f"Wrote {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation

- Centralize the AI assistant knowledge, sales playbooks, and marketing content system for K Fitness Center.  
- Provide a repeatable, safety-conscious automated content creation workflow and templates for social posts and videos.  
- Supply a simple generator to convert the workflow data into a ready-to-review production brief.

### Description

- Update `README.md` with the AI assistant role, business source-of-truth, sales style, safety rules, and marketing post structure.  
- Add `data/content-workflow.json` to define the automated content creation workflow, weekly calendar, and publishing checklist.  
- Add `docs/assistant-playbook.md` and `docs/automated-content-workflow.md` containing multilingual reply templates, sales scripts, marketing examples, and a step-by-step workflow.  
- Add `scripts/generate_content_workflow.py` which loads the JSON workflow and renders a markdown production brief, and include a generated example at `output/k-fitness-content-brief.md`.

### Testing

- Executed the generator with `python3 scripts/generate_content_workflow.py` which successfully wrote `output/k-fitness-content-brief.md` and exited with status 0.  
- No unit tests were added in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a290a37e9a88333a69d852dd2e70b2f)